### PR TITLE
Simplify @odata.context for auto select entities

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClause.cs
@@ -68,6 +68,12 @@ namespace Microsoft.OData.UriParser
             }
         }
 
+        /// <summary>
+        /// Gets a flag indicating that auto select was set on an entity type level.
+        /// </summary>
+        /// <remarks>
+        /// In that case SelectedItems will contain a lot of records (all properties for the type), but we should ignore these properties when writing @odata.context
+        /// </remarks>
         public bool AllAutoSelected { get; set; }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClause.cs
@@ -34,10 +34,11 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="selectedItems">The selected properties and operations. This list should include any expanded navigation properties.</param>
         /// <param name="allSelected">Flag indicating if all items have been selected at this level.</param>
-        public SelectExpandClause(IEnumerable<SelectItem> selectedItems, bool allSelected)
+        public SelectExpandClause(IEnumerable<SelectItem> selectedItems, bool allSelected, bool allAutoSelected = false)
         {
             this.selectedItems = selectedItems != null ? new ReadOnlyCollection<SelectItem>(selectedItems.ToList()) : new ReadOnlyCollection<SelectItem>(new List<SelectItem>());
             this.allSelected = allSelected;
+            this.AllAutoSelected = allAutoSelected;
         }
 
         /// <summary>
@@ -66,6 +67,8 @@ namespace Microsoft.OData.UriParser
                 return this.allSelected.Value;
             }
         }
+
+        public bool AllAutoSelected { get; set; }
 
         /// <summary>
         /// Add a select item to the current list of selection items
@@ -108,7 +111,7 @@ namespace Microsoft.OData.UriParser
         /// Sets all the value of AllSelected
         /// </summary>
         /// <param name="newValue">the new value to set</param>
-        internal void SetAllSelected(bool newValue)
+        public void SetAllSelected(bool newValue)
         {
             this.allSelected = newValue;
         }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -87,15 +87,15 @@ namespace Microsoft.OData.UriParser
             {
                 return selectExpandClause.SelectedItems
                     .OfType<ExpandedNavigationSelectItem>()
-                    .Select(i => String.Join("/", i.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray()))
+                    .Select(i => String.Join("/", i.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance)))
                     .ToList();
-                //return new List<string>();
             }
             else
             {
                 return selectExpandClause.SelectedItems
                     .Select(GetSelectString)
-                    .Where(i => i != null).ToList();
+                    .Where(i => i != null)
+                    .ToList();
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -83,7 +83,20 @@ namespace Microsoft.OData.UriParser
         /// <returns>String list generated from selected items</returns>
         internal static List<string> GetCurrentLevelSelectList(this SelectExpandClause selectExpandClause)
         {
-            return selectExpandClause.SelectedItems.Select(GetSelectString).Where(i => i != null).ToList();
+            if (selectExpandClause.AllAutoSelected)
+            {
+                return selectExpandClause.SelectedItems
+                    .OfType<ExpandedNavigationSelectItem>()
+                    .Select(i => String.Join("/", i.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray()))
+                    .ToList();
+                //return new List<string>();
+            }
+            else
+            {
+                return selectExpandClause.SelectedItems
+                    .Select(GetSelectString)
+                    .Where(i => i != null).ToList();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Don't include all properties to @odata.context when entity level auto selected is used
