### PR TITLE
Parsing and binding for compute inside $apply

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1491,6 +1491,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\Aggregation\FilterTransformationNode.cs">
       <Link>Microsoft\OData\Core\UriParser\Aggregation\FilterTransformationNode.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\Aggregation\ComputeTransformationNode.cs">
+      <Link>Microsoft\OData\Core\UriParser\Aggregation\ComputeTransformationNode.cs</Link>
+    </Compile>    
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\Aggregation\TransformationNode.cs">
       <Link>Microsoft\OData\Core\UriParser\Aggregation\TransformationNode.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -1013,6 +1013,9 @@
     <Compile Include="..\UriParser\Aggregation\FilterTransformationNode.cs">
       <Link>UriParser\Aggregation\FilterTransformationNode.cs</Link>
     </Compile>
+    <Compile Include="..\UriParser\Aggregation\ComputeTransformationNode.cs">
+      <Link>UriParser\Aggregation\ComputeTransformationNode.cs</Link>
+    </Compile>    
     <Compile Include="..\UriParser\Aggregation\GroupByPropertyNode.cs">
       <Link>UriParser\Aggregation\GroupByPropertyNode.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -80,6 +80,7 @@
     <Compile Include="DuplicatePropertyNameChecker.cs" />
     <Compile Include="PropertyValueTypeInfo.cs" />
     <Compile Include="BindingPathHelper.cs" />
+    <Compile Include="UriParser\Aggregation\ComputeTransformationNode.cs" />
     <Compile Include="UriParser\Binders\ComputeBinder.cs" />
     <Compile Include="UriParser\Binders\ErrorCodes.cs" />
     <Compile Include="UriParser\ODataPathInfo.cs" />

--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -207,6 +207,9 @@ namespace Microsoft.OData
         /// <summary>"filter" keyword for $apply.</summary>
         internal const string KeywordFilter = "filter";
 
+        /// <summary>"compute" keyword for $apply.</summary>
+        internal const string KeywordCompute = "compute";
+
         /// <summary>"groupby" keyword for $apply.</summary>
         internal const string KeywordGroupBy = "groupby";
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -55,6 +55,9 @@ namespace Microsoft.OData.UriParser.Aggregation
                         var computeClause = this.computeBinder.BindCompute((ComputeToken)token);
                         var computeNode = new ComputeTransformationNode(computeClause);
                         transformations.Add(computeNode);
+                        state.AggregatedPropertyNames =
+                                computeNode.ComputeClause.ComputedItems.Select(statement => statement.Alias).ToList();
+
                         break;
                     default:
                         var filterClause = this.filterBinder.BindFilter(token);

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -19,6 +19,7 @@ namespace Microsoft.OData.UriParser.Aggregation
         private BindingState state;
 
         private FilterBinder filterBinder;
+        private ComputeBinder computeBinder;
 
         private IEnumerable<AggregateExpression> aggregateExpressionsCache;
 
@@ -27,6 +28,7 @@ namespace Microsoft.OData.UriParser.Aggregation
             this.bindMethod = bindMethod;
             this.state = state;
             this.filterBinder = new FilterBinder(bindMethod, state);
+            this.computeBinder = new ComputeBinder(bindMethod);
         }
 
         public ApplyClause BindApply(IEnumerable<QueryToken> tokens)
@@ -48,6 +50,11 @@ namespace Microsoft.OData.UriParser.Aggregation
                     case QueryTokenKind.AggregateGroupBy:
                         var groupBy = BindGroupByToken((GroupByToken)(token));
                         transformations.Add(groupBy);
+                        break;
+                    case QueryTokenKind.Compute:
+                        var computeClause = this.computeBinder.BindCompute((ComputeToken)token);
+                        var computeNode = new ComputeTransformationNode(computeClause);
+                        transformations.Add(computeNode);
                         break;
                     default:
                         var filterClause = this.filterBinder.BindFilter(token);

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -41,27 +41,24 @@ namespace Microsoft.OData.UriParser.Aggregation
                 switch (token.Kind)
                 {
                     case QueryTokenKind.Aggregate:
-                        var aggregate = BindAggregateToken((AggregateToken)(token));
+                        AggregateTransformationNode aggregate = BindAggregateToken((AggregateToken)(token));
                         transformations.Add(aggregate);
                         aggregateExpressionsCache = aggregate.Expressions;
-                        state.AggregatedPropertyNames =
-                            aggregate.Expressions.Select(statement => statement.Alias).ToList();
+                        state.AggregatedPropertyNames = aggregate.Expressions.Select(statement => statement.Alias).ToList();
                         break;
                     case QueryTokenKind.AggregateGroupBy:
-                        var groupBy = BindGroupByToken((GroupByToken)(token));
+                        GroupByTransformationNode groupBy = BindGroupByToken((GroupByToken)(token));
                         transformations.Add(groupBy);
                         break;
                     case QueryTokenKind.Compute:
-                        var computeClause = this.computeBinder.BindCompute((ComputeToken)token);
-                        var computeNode = new ComputeTransformationNode(computeClause);
+                        ComputeClause computeClause = this.computeBinder.BindCompute((ComputeToken)token);
+                        ComputeTransformationNode computeNode = new ComputeTransformationNode(computeClause);
                         transformations.Add(computeNode);
-                        state.AggregatedPropertyNames =
-                                computeNode.ComputeClause.ComputedItems.Select(statement => statement.Alias).ToList();
-
+                        state.AggregatedPropertyNames = computeNode.ComputeClause.ComputedItems.Select(statement => statement.Alias).ToList();
                         break;
                     default:
-                        var filterClause = this.filterBinder.BindFilter(token);
-                        var filterNode = new FilterTransformationNode(filterClause);
+                        FilterClause filterClause = this.filterBinder.BindFilter(token);
+                        FilterTransformationNode filterNode = new FilterTransformationNode(filterClause);
                         transformations.Add(filterNode);
                         break;
                 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ComputeTransformationNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ComputeTransformationNode.cs
@@ -1,0 +1,51 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ComputeTransformationNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.UriParser.Aggregation
+{
+    using Microsoft.OData.UriParser;
+
+    /// <summary>
+    /// Node representing a Compute transformation.
+    /// </summary>
+    public sealed class ComputeTransformationNode : TransformationNode
+    {
+        private readonly ComputeClause computeClause;
+
+        /// <summary>
+        /// Create a ComputeTransformationNode.
+        /// </summary>
+        /// <param name="ComputeClause">A <see cref="ComputeClause"/> representing the metadata bound Compute expression.</param>
+        public ComputeTransformationNode(ComputeClause computeClause)
+        {
+            ExceptionUtils.CheckArgumentNotNull(computeClause, "computeClause");
+
+            this.computeClause = computeClause;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ComputeClause"/> representing the metadata bound Compute expression.
+        /// </summary>
+        public ComputeClause ComputeClause
+        {
+            get
+            {
+                return this.computeClause;
+            }
+        }
+
+        /// <summary>
+        /// Gets the kind of the transformation node.
+        /// </summary>
+        public override TransformationNodeKind Kind
+        {
+            get
+            {
+                return TransformationNodeKind.Compute;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/TransformationNodeKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/TransformationNodeKind.cs
@@ -25,5 +25,10 @@ namespace Microsoft.OData.UriParser.Aggregation
         /// A filter clause
         /// </summary>
         Filter = 2,
+
+        /// <summary>
+        /// A compute clause
+        /// </summary>
+        Compute = 3,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// List of supported $apply keywords
         /// </summary>
-        private static readonly string supportedKeywords = string.Join("|", new string[] { ExpressionConstants.KeywordAggregate, ExpressionConstants.KeywordFilter, ExpressionConstants.KeywordGroupBy });
+        private static readonly string supportedKeywords = string.Join("|", new string[] { ExpressionConstants.KeywordAggregate, ExpressionConstants.KeywordFilter, ExpressionConstants.KeywordGroupBy, ExpressionConstants.KeywordCompute });
 
         /// <summary>
         /// Set of parsed parameters
@@ -261,6 +261,9 @@ namespace Microsoft.OData.UriParser
                     case ExpressionConstants.KeywordFilter:
                         transformationTokens.Add(ParseApplyFilter());
                         break;
+                    case ExpressionConstants.KeywordCompute:
+                        transformationTokens.Add(ParseApplyCompute());
+                        break;
                     case ExpressionConstants.KeywordGroupBy:
                         transformationTokens.Add(ParseGroupBy());
                         break;
@@ -435,6 +438,49 @@ namespace Microsoft.OData.UriParser
             // '(' expression ')'
             return this.ParseParenExpression();
         }
+
+        // parses $apply compute tranformation (.e.g. compute(Price mul Qty as Total))
+        internal QueryToken ParseApplyCompute()
+        {
+            Debug.Assert(TokenIdentifierIs(ExpressionConstants.KeywordCompute), "token identifier is compute");
+            lexer.NextToken();
+
+            // '('
+            if (this.lexer.CurrentToken.Kind != ExpressionTokenKind.OpenParen)
+            {
+                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_OpenParenExpected(this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
+            }
+
+            this.lexer.NextToken();
+
+            // series of statements separates by commas
+            List<ComputeExpressionToken> transformationTokens = new List<ComputeExpressionToken>();
+
+            while (true)
+            {
+                ComputeExpressionToken computed = this.ParseComputeExpression();
+                transformationTokens.Add(computed);
+                if (this.lexer.CurrentToken.Kind != ExpressionTokenKind.Comma)
+                {
+                    break;
+                }
+
+                this.lexer.NextToken();
+            }
+
+            // ")"
+            if (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
+            {
+                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_CloseParenOrCommaExpected(this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
+            }
+
+            this.lexer.NextToken();
+
+
+            //// '(' expression ')'
+            return new ComputeToken(transformationTokens);
+        }
+
 
         /// <summary>
         /// Parse compute expression text into a token.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -218,6 +218,30 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
+        public void BindApplyWitComputeShouldReturnApplyClause()
+        {
+            var tokens = _parser.ParseApply("compute(UnitPrice mul 5 as BigPrice)");
+
+            var binder = new ApplyBinder(FakeBindMethods.BindSingleComplexProperty, _bindingState);
+            var actual = binder.BindApply(tokens);
+
+            actual.Should().NotBeNull();
+            actual.Transformations.Should().HaveCount(1);
+
+            var transformations = actual.Transformations.ToList();
+            var compute = transformations[0] as ComputeTransformationNode;
+
+            compute.Should().NotBeNull();
+            compute.Kind.Should().Be(TransformationNodeKind.Compute);
+            compute.ComputeClause.ComputedItems.Should().HaveCount(1);
+
+            var statements = compute.ComputeClause.ComputedItems.ToList();
+            var statement = statements[0];
+            VerifyIsFakeSingleValueNode(statement.Expression);
+            statement.Alias.ShouldBeEquivalentTo("BigPrice");
+        }
+
+        [Fact]
         public void BindApplyWitMultipleTokensShouldReturnApplyClause()
         {
             var tokens =

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var apply = "invalid(UnitPrice with sum as TotalPrice)";
             Action parse = () => this.testSubject.ParseApply(apply);
-            parse.ShouldThrow<ODataException>().Where(e => e.Message == ErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected("aggregate|filter|groupby",0,apply));
+            parse.ShouldThrow<ODataException>().Where(e => e.Message == ErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected("aggregate|filter|groupby|compute",0,apply));
         }
 
         [Fact]
@@ -396,7 +396,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var apply = "groupBy((UnitPrice), aggregate(UnitPrice with sum as TotalPrice)";
             Action parse = () => this.testSubject.ParseApply(apply);
-            parse.ShouldThrow<ODataException>().Where(e => e.Message == ErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected("aggregate|filter|groupby", 0, apply));
+            parse.ShouldThrow<ODataException>().Where(e => e.Message == ErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected("aggregate|filter|groupby|compute", 0, apply));
         }
 
         [Fact]
@@ -532,6 +532,31 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             VerifyAggregateExpressionToken("CustomerId", AggregationMethodDefinition.Sum, "Total", aggregateExpressions[0]);
             VerifyAggregateExpressionToken("SharePrice", AggregationMethodDefinition.CountDistinct, "SharePriceDistinctCount", aggregateExpressions[1]);
         }
+
+        [Fact]
+        public void ParseApplyWithComputeWithMathematicalOperations()
+        {
+            string compute = "compute(Prop1 mul Prop2 as Product,Prop1 div Prop2 as Ratio,Prop2 mod Prop2 as Remainder)";
+            ComputeToken token = this.testSubject.ParseApply(compute).First() as ComputeToken;
+            token.Kind.ShouldBeEquivalentTo(QueryTokenKind.Compute);
+            List<ComputeExpressionToken> tokens = token.Expressions.ToList();
+            tokens.Count.Should().Be(3);
+            tokens[0].Kind.ShouldBeEquivalentTo(QueryTokenKind.ComputeExpression);
+            tokens[1].Kind.ShouldBeEquivalentTo(QueryTokenKind.ComputeExpression);
+            tokens[2].Kind.ShouldBeEquivalentTo(QueryTokenKind.ComputeExpression);
+            tokens[0].Alias.ShouldBeEquivalentTo("Product");
+            tokens[1].Alias.ShouldBeEquivalentTo("Ratio");
+            tokens[2].Alias.ShouldBeEquivalentTo("Remainder");
+            (tokens[0].Expression as BinaryOperatorToken).OperatorKind.ShouldBeEquivalentTo(BinaryOperatorKind.Multiply);
+            (tokens[1].Expression as BinaryOperatorToken).OperatorKind.ShouldBeEquivalentTo(BinaryOperatorKind.Divide);
+            (tokens[2].Expression as BinaryOperatorToken).OperatorKind.ShouldBeEquivalentTo(BinaryOperatorKind.Modulo);
+
+            Action accept1 = () => tokens[0].Accept<ComputeExpression>(null);
+            accept1.ShouldThrow<NotImplementedException>();
+            Action accept2 = () => token.Accept<ComputeExpression>(null);
+            accept2.ShouldThrow<NotImplementedException>();
+        }
+
 
         [Fact]
         public void ParseComputeWithMathematicalOperations()

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -6752,6 +6752,7 @@ public enum Microsoft.OData.UriParser.Aggregation.AggregationMethod : int {
 
 public enum Microsoft.OData.UriParser.Aggregation.TransformationNodeKind : int {
 	Aggregate = 0
+	Compute = 3
 	Filter = 2
 	GroupBy = 1
 }
@@ -6824,6 +6825,13 @@ public sealed class Microsoft.OData.UriParser.Aggregation.ApplyClause {
 	public ApplyClause (System.Collections.Generic.IList`1[[Microsoft.OData.UriParser.Aggregation.TransformationNode]] transformations)
 
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.Aggregation.TransformationNode]] Transformations  { public get; }
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.ComputeTransformationNode : Microsoft.OData.UriParser.Aggregation.TransformationNode {
+	public ComputeTransformationNode (Microsoft.OData.UriParser.ComputeClause computeClause)
+
+	Microsoft.OData.UriParser.ComputeClause ComputeClause  { public get; }
+	Microsoft.OData.UriParser.Aggregation.TransformationNodeKind Kind  { public virtual get; }
 }
 
 public sealed class Microsoft.OData.UriParser.Aggregation.FilterTransformationNode : Microsoft.OData.UriParser.Aggregation.TransformationNode {


### PR DESCRIPTION
ODL 7.4 added support for $compute parsing, but skipped compute inside $apply. Adding that feature.