### PR TITLE
Ensure that we can use aliases genearted in compute on later stages

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private readonly IEnumerable<GroupByPropertyNode> lastGroupByPropertyNodes;
 
-        private readonly IEnumerable<ComputeExpression> lastComputeExpressions;
+        private readonly List<ComputeExpression> lastComputeExpressions;
 
         /// <summary>
         /// Create a ApplyClause.
@@ -55,10 +55,8 @@ namespace Microsoft.OData.UriParser.Aggregation
                 }
                 else if (transformations[i].Kind == TransformationNodeKind.Compute)
                 {
-                    if (lastAggregateExpressions == null)
-                    {
-                        lastComputeExpressions = (transformations[i] as ComputeTransformationNode).ComputeClause.ComputedItems;
-                    }
+                    lastComputeExpressions = lastComputeExpressions ?? new List<ComputeExpression>();
+                    lastComputeExpressions.AddRange((transformations[i] as ComputeTransformationNode).ComputeClause.ComputedItems);
                 }
             }
         }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -21,6 +21,8 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private readonly IEnumerable<GroupByPropertyNode> lastGroupByPropertyNodes;
 
+        private readonly IEnumerable<ComputeExpression> lastComputeExpressions;
+
         /// <summary>
         /// Create a ApplyClause.
         /// </summary>
@@ -51,6 +53,13 @@ namespace Microsoft.OData.UriParser.Aggregation
 
                     break;
                 }
+                else if (transformations[i].Kind == TransformationNodeKind.Compute)
+                {
+                    if (lastAggregateExpressions == null)
+                    {
+                        lastComputeExpressions = (transformations[i] as ComputeTransformationNode).ComputeClause.ComputedItems;
+                    }
+                }
             }
         }
 
@@ -72,12 +81,21 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         internal List<string> GetLastAggregatedPropertyNames()
         {
-            if (lastAggregateExpressions != null)
+            if (lastAggregateExpressions == null && lastComputeExpressions == null)
             {
-                return lastAggregateExpressions.Select(statement => statement.Alias).ToList();
+                return null;
             }
 
-            return null;
+            List<string> result = new List<string>();
+            if (lastAggregateExpressions != null)
+            {
+                result.AddRange(lastAggregateExpressions.Select(statement => statement.Alias));
+            }
+            if (lastComputeExpressions != null)
+            {
+                result.AddRange(lastComputeExpressions.Select(statement => statement.Alias));
+            }
+            return result;
         }
 
         private string CreatePropertiesUriSegment(

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1197,6 +1197,25 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void MultipleComputePropertiesTreatedAsOpenPropertyInOrderBy()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$orderby", "DoubleTotal1 asc, DoubleTotal2 desc"},
+                    {"$apply", "aggregate(FavoriteNumber with sum as Total)/compute(Total mul 2 as DoubleTotal1)/compute(DoubleTotal1 mul 2 as DoubleTotal2)"}
+                });
+            odataQueryOptionParser.ParseApply();
+            var orderByClause = odataQueryOptionParser.ParseOrderBy();
+            orderByClause.Direction.Should().Be(OrderByDirection.Ascending);
+            orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("DoubleTotal1");
+            orderByClause = orderByClause.ThenBy;
+            orderByClause.Direction.Should().Be(OrderByDirection.Descending);
+            orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("DoubleTotal2");
+        }
+
+        [Fact]
         public void ReferenceComputeAliasCreatedBeforeAggrageteThrows()
         {
             var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,


### PR DESCRIPTION
Ensure that parses can bind properties introduced in compute in orderby or filter