### PR TITLE
Users/prneelak/propertyexception

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -45,10 +45,12 @@ namespace Microsoft.OData.UriParser.Aggregation
                         transformations.Add(aggregate);
                         aggregateExpressionsCache = aggregate.Expressions;
                         state.AggregatedPropertyNames = aggregate.Expressions.Select(statement => statement.Alias).ToList();
+                        state.IsCollapsed = true;
                         break;
                     case QueryTokenKind.AggregateGroupBy:
                         GroupByTransformationNode groupBy = BindGroupByToken((GroupByToken)(token));
                         transformations.Add(groupBy);
+                        state.IsCollapsed = true;
                         break;
                     case QueryTokenKind.Compute:
                         ComputeClause computeClause = this.computeBinder.BindCompute((ComputeToken)token);

--- a/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
@@ -142,6 +142,11 @@ namespace Microsoft.OData.UriParser
         internal List<string> AggregatedPropertyNames { get; set; }
 
         /// <summary>
+        /// The property set when group by or aggregation is done and properties are collapsed out of scope
+        /// </summary>
+        internal bool IsCollapsed { get; set; }
+
+        /// <summary>
         /// The parsed segments in path and query option.
         /// </summary>
         internal List<ODataPathSegment> ParsedSegments

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.OData.UriParser
             }
             else
             {
-               throw ExceptionUtil.CreatePropertyNotFoundException(endPathToken.Identifier, parentNode.TypeReference.FullName(), true);
+               throw ExceptionUtil.CreatePropertyNotFoundException(endPathToken.Identifier, parentNode.TypeReference.FullName(), state.IsCollapsed);
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.OData.UriParser
             }
             else
             {
-               throw ExceptionUtil.CreatePropertyNotFoundException(endPathToken.Identifier, parentNode.TypeReference.FullName());
+               throw ExceptionUtil.CreatePropertyNotFoundException(endPathToken.Identifier, parentNode.TypeReference.FullName(), true);
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/ErrorCodes.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/ErrorCodes.cs
@@ -9,5 +9,6 @@ namespace Microsoft.OData.UriParser
     internal static class ErrorCodes
     {
         public const string PropertyNotFoundInType = "10001";
+        public const string OpenPropertyNotFoundInType = "10002";
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/ExceptionUtil.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExceptionUtil.cs
@@ -70,23 +70,27 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="propertyName">The propertyName which was not found in the type.</param>
         /// <param name="typeName">The typeName of the type in which the property was not found.</param>
-        internal static ODataErrorException CreatePropertyNotFoundException(string propertyName, string typeName)
+        internal static ODataErrorException CreatePropertyNotFoundException(string propertyName, string typeName , bool isOpenProperty = false)
         {
-            ODataError odataError = new ODataError
-            {
-                ErrorCode = ErrorCodes.PropertyNotFoundInType,
-                Target = propertyName,
-                Details = new List<ODataErrorDetail>
-                    {
-                        new ODataErrorDetail {
-                            ErrorCode = ErrorCodes.PropertyNotFoundInType,
-                            Target = typeName
-                        }
-                    }
-            };
+            ODataError odataError = GenerateODataError(propertyName, typeName, isOpenProperty? ErrorCodes.OpenPropertyNotFoundInType: ErrorCodes.PropertyNotFoundInType);
 
             return new ODataErrorException(ODataErrorStrings.MetadataBinder_PropertyNotDeclared(typeName, propertyName), odataError);
         }
 
+        private static ODataError GenerateODataError(string propertyName, string typeName, string errorCode)
+        {
+            return new ODataError
+            {
+                ErrorCode = errorCode,
+                Target = propertyName,
+                Details = new List<ODataErrorDetail>
+                    {
+                        new ODataErrorDetail {
+                            ErrorCode = errorCode,
+                            Target = typeName
+                        }
+                    }
+            };
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -384,6 +384,8 @@ namespace Microsoft.OData.UriParser
             if (applyClause != null)
             {
                 state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
+                if(applyClause.Transformations.Any(x=>x.Kind==TransformationNodeKind.GroupBy || x.Kind==TransformationNodeKind.Aggregate))
+                   state.IsCollapsed = true;
             }
 
             MetadataBinder binder = new MetadataBinder(state);
@@ -470,6 +472,8 @@ namespace Microsoft.OData.UriParser
             if (applyClause != null)
             {
                 state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
+                if (applyClause.Transformations.Any(x => x.Kind == TransformationNodeKind.GroupBy || x.Kind == TransformationNodeKind.Aggregate))
+                    state.IsCollapsed = true;
             }
 
             MetadataBinder binder = new MetadataBinder(state);

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -384,8 +384,10 @@ namespace Microsoft.OData.UriParser
             if (applyClause != null)
             {
                 state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
-                if(applyClause.Transformations.Any(x=>x.Kind==TransformationNodeKind.GroupBy || x.Kind==TransformationNodeKind.Aggregate))
-                   state.IsCollapsed = true;
+                if (applyClause.Transformations.Any(x => x.Kind == TransformationNodeKind.GroupBy || x.Kind == TransformationNodeKind.Aggregate))
+                {
+                    state.IsCollapsed = true;
+                }
             }
 
             MetadataBinder binder = new MetadataBinder(state);
@@ -473,7 +475,9 @@ namespace Microsoft.OData.UriParser
             {
                 state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
                 if (applyClause.Transformations.Any(x => x.Kind == TransformationNodeKind.GroupBy || x.Kind == TransformationNodeKind.Aggregate))
+                {
                     state.IsCollapsed = true;
+                }
             }
 
             MetadataBinder binder = new MetadataBinder(state);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -92,6 +92,39 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
+        public void BindApplyWithNonExistingPropertyShouldThrowPropertyException()
+        {
+            var tokens = _parser.ParseApply("filter(IDx eq 0)");
+            var metadataBiner = new MetadataBinder(_bindingState);
+
+            var binder = new ApplyBinder(metadataBiner.Bind, _bindingState);
+            Action bind = () => binder.BindApply(tokens);
+            bind.ShouldThrow<ODataErrorException>().Where(e => e.Error.ErrorCode == ErrorCodes.PropertyNotFoundInType);
+        }
+
+        [Fact]
+        public void BindApplyWithAggregateNonExistingOpenPropertyShouldThrowOpenPropertyException()
+        {
+            var tokens = _parser.ParseApply("aggregate($count as Ct)/filter(Cxt eq 0)");
+
+            var metadataBiner = new MetadataBinder(_bindingState);
+            var binder = new ApplyBinder(metadataBiner.Bind, _bindingState);
+            Action bind = () => binder.BindApply(tokens);
+            bind.ShouldThrow<ODataErrorException>().Where(e => e.Error.ErrorCode == ErrorCodes.OpenPropertyNotFoundInType);
+        }
+
+        [Fact]
+        public void BindApplyWithGroupByNonExistingOpenPropertyShouldThrowOpenPropertyException()
+        {
+            var tokens = _parser.ParseApply("groupby((ID))/filter(Cxt eq 0)");
+
+            var metadataBiner = new MetadataBinder(_bindingState);
+            var binder = new ApplyBinder(metadataBiner.Bind, _bindingState);
+            Action bind = () => binder.BindApply(tokens);
+            bind.ShouldThrow<ODataErrorException>().Where(e => e.Error.ErrorCode == ErrorCodes.OpenPropertyNotFoundInType);
+        }
+
+        [Fact]
         public void BindApplyWithAggregateAndFilterShouldReturnApplyClause()
         {
             var tokens = _parser.ParseApply("aggregate(StockQuantity with sum as TotalPrice)/filter(TotalPrice eq 100)");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
-        public void BindApplyWithNonExistingPropertyShouldThrowPropertyException()
+        public void BindApplyWithFilterNonExistingPropertyShouldThrowPropertyException()
         {
             var tokens = _parser.ParseApply("filter(IDx eq 0)");
             var metadataBiner = new MetadataBinder(_bindingState);
@@ -103,7 +103,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
-        public void BindApplyWithAggregateNonExistingOpenPropertyShouldThrowOpenPropertyException()
+        public void BindApplyWithAggregateFilterOnNonExistingOpenPropertyShouldThrowOpenPropertyException()
         {
             var tokens = _parser.ParseApply("aggregate($count as Ct)/filter(Cxt eq 0)");
 
@@ -114,7 +114,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
-        public void BindApplyWithGroupByNonExistingOpenPropertyShouldThrowOpenPropertyException()
+        public void BindApplyWithGroupByFilterOnNonExistingOpenPropertyShouldThrowOpenPropertyException()
         {
             var tokens = _parser.ParseApply("groupby((ID))/filter(Cxt eq 0)");
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

This PR fixes issues with handling of separate property not found exceptions .

In general there are two kinds of exceptions we want to separate -
1) Property not found in original entity
2) Property not found after collapse of original properties and declaration of new properties in group by or aggregate .
